### PR TITLE
Fix StreamingCN Bilibili

### DIFF
--- a/Clash/RuleSet/StreamingMedia/StreamingCN.yaml
+++ b/Clash/RuleSet/StreamingMedia/StreamingCN.yaml
@@ -6,6 +6,9 @@ payload:
   # > bilibili
   - DOMAIN-SUFFIX,bilivideo.com
   - DOMAIN,api.bilibili.com
+  - DOMAIN,www.bilibili.com
+  - DOMAIN,interface.bilibili.com
+  - DOMAIN,bangumi.bilibili.com
   # > Tencent Video
   - DOMAIN-SUFFIX,video.qq.com
   - DOMAIN-SUFFIX,v.qq.com

--- a/Clash/RuleSet/StreamingMedia/StreamingCN.yaml
+++ b/Clash/RuleSet/StreamingMedia/StreamingCN.yaml
@@ -5,10 +5,12 @@ payload:
   - DOMAIN-SUFFIX,aixifan.com
   # > bilibili
   - DOMAIN-SUFFIX,bilivideo.com
-  - DOMAIN,api.bilibili.com
+  - DOMAIN-SUFFIX,biliapi.net
+  - DOMAIN-SUFFIX,hdslb.com
   - DOMAIN,www.bilibili.com
-  - DOMAIN,interface.bilibili.com
+  - DOMAIN,api.bilibili.com
   - DOMAIN,bangumi.bilibili.com
+  - DOMAIN,interface.bilibili.com
   # > Tencent Video
   - DOMAIN-SUFFIX,video.qq.com
   - DOMAIN-SUFFIX,v.qq.com


### PR DESCRIPTION
根据本地log和unblock youku插件规则，修复海外用户不能观看bilibili新番的问题

已在本机测试

短期内可持续帮助维护StreamingCN部分规则