### PR TITLE
bilibili splash ads

### DIFF
--- a/Quantumult/Rewrite/Block/Advertising.conf
+++ b/Quantumult/Rewrite/Block/Advertising.conf
@@ -91,7 +91,7 @@ hostname = api.weibo.cn,mapi.weibo.com,www.zhihu.com,api.21jingji.com,service.4g
 ^https?:\/\/act\.vip\.iqiyi\.com\/interact\/api\/v\d\/show url reject
 # ---
 # > bilibili - app.bilibili.com,manga.bilibili.com
-^https?:\/\/app\.bilibili\.com\/x\/v\d\/splash\/ url reject
+^https?:\/\/app\.bilibili\.com\/x\/v2\/splash\/list url script-response-body https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/script/bilibili/bilibili_plus.js
 ^https?:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/Flash url reject
 # > BeiTaiKitchen - channel.beitaichufang.com
 ^https?:\/\/channel\.beitaichufang\.com\/channel\/api\/v\d\/promote\/ios\/start\/page url reject


### PR DESCRIPTION
https://github.com/blackmatrix7/ios_rule_script/tree/master/script/bilibili

> 目前几乎所有的整合型去广告规则都带有去除哔哩哔哩开屏广告的规则。通过对类似^https?:\/\/app\.bilibili\.com\/x\/v2\/splash\/list  
正则复写的拦截来屏蔽开屏广告。这在大部分情况下都是有效的，但是如果忘记打开VPN或其他原因导致拦截失败，开屏广告缓存到APP中后，下次启动开屏广告就会出现。此时再通过正则去拦截已无能为力，只能重装APP或等待广告过期。  
在本项目的去广告策略中，采取的是对开屏广告请求进行放行，同时通过脚本将广告生效时间设置到2030年以去除开屏广告。这样做的好处是即使某次拦截失败，下次APP重新请求一次广告后，开屏广告就会消失，不需要重装APP。