### PR TITLE
Driver update address of GeForce Experience

### DIFF
--- a/Clash/RuleSet/Global.yaml
+++ b/Clash/RuleSet/Global.yaml
@@ -431,7 +431,9 @@ payload:
   - DOMAIN-SUFFIX,zello.com
   - DOMAIN-SUFFIX,zeronet.io
   - DOMAIN-SUFFIX,zoom.us
-
+  
+  - DOMAIN,international-gfe.download.nvidia.com
+  
   - DOMAIN,cc.tvbs.com.tw
   - DOMAIN,ocsp.int-x3.letsencrypt.org
   - DOMAIN,search.avira.com


### PR DESCRIPTION
这是 GeForce Experience 更新驱动的国际线路，会因为 China.yaml 里的 nvidia.com 的规则走直连，导致下载速度极慢。