### PR TITLE
OriginPro 软件激活服务

### DIFF
--- a/Clash/RuleSet/China.yaml
+++ b/Clash/RuleSet/China.yaml
@@ -334,6 +334,7 @@ payload:
   - DOMAIN-SUFFIX,zhihuishu.com
   - DOMAIN-SUFFIX,zhimg.com
   - DOMAIN-SUFFIX,zhuihd.com
+  - DOMAIN-SUFFIX,originlab.com
 
   - DOMAIN,download.jetbrains.com
   - DOMAIN,images-cn.ssl-images-amazon.com


### PR DESCRIPTION
OriginLab 为中国学生提供了学生版，但激活和使用需要在中国大陆，该域名走代理会导致不能正常激活 OriginPro 软件。