### PR TITLE
3 in 1 external configs for subconverter

### DIFF
--- a/Clash/Inbound.yaml
+++ b/Clash/Inbound.yaml
@@ -194,7 +194,7 @@ proxies:
     #   - http/1.1
     # skip-cert-verify: true
 
-# 节点订阅
+# 服务器节点订阅
 proxy-providers:
   # name: # Provider 名称
   #   type: http # http 或 file
@@ -206,6 +206,16 @@ proxy-providers:
   #     url: 
   #     interval: 
 
+  #
+  # 「url」参数填写订阅链接
+  #
+  # 订阅链接可以使用 API 进行转换，如：https://dove.589669.xyz/web
+  #
+  #
+
+  # 此处只是订阅示例，如果没有订阅链接的使用需求，此处及 proxy-groups 的相关内容可删除
+
+  
   # DuckDuckGo: # 冲鸭机场订阅链接
   #   type: http
   #   url: "https://duckduckgo.security/user/sub.php?token=DivineEngine"
@@ -219,8 +229,45 @@ proxy-providers:
 proxy-groups:
 # 策略组示例请查阅 Clash 项目 README 以使用最新格式：https://github.com/Dreamacro/clash/wiki/configuration
 
+#
+# 策略组说明
+#
+# 「MATCH」类似 Surge 的「Final」，此处用于选择白名单模式(PROXY 策略)和黑名单模式(DIRECT 策略)
+#
+# 「Streaming」和「StreamingSE」比较好理解，有专用于流媒体的节点就设置到其中，如果没有「StreamingSE」的需求可以连带 Rule 部分一起删掉，「Streaming」需至少保留 Rule，用「PROXY」即可。
+#
+# 「PROXY」是代理规则策略，它可以指定为某个节点或嵌套一个其他策略组，如：「自动测试」、「Fallback」或「负载均衡」的策略组，关于这 3 个策略组的具体示例可以看官方示例：https://github.com/Dreamacro/clash
+#
+
+  # 注意此处的「use」而不是「proxies」，当然也可以不用在此先嵌套一个策略组进行选择，可以直接使用，如
+  #
+  # # 代理节点选择
+  # - name: "PROXY"
+  #   type: select
+  #   use:
+  #     - DuckDuckGo # 嵌套使用订阅节点策略组
+  #   proxies:
+  #     - Fallback
+  #     - 1
+  #     - 2
+  #     - 3
+  #
+  # 但如果订阅节点很多选起来就很麻烦，不如先嵌套一个策略组进行手动或自动的选择。
+
+  # 手动选择订阅节点
+  - name: "🦆DuckDuckGo"
+    type: select # 亦可使用 fallback 或 load-balance
+    use: # 注意此处是「use」
+      - DuckDuckGoList # 这是上面「proxy-providers」的名称
+
+  # - name: "US"
+  #   type: select # 亦可使用 fallback 或 load-balance
+  #   use: # 注意此处是「use」
+  #     - DuckDuckGoUS # 这是上面「proxy-providers」的名称
+
+  # Fallback 比较实用的策略组类型，用于测试服务器节点的可用性，当第一个节点不可用时切换到第二个，以此类推。
   # Fallback
-  - name: "Fallback"
+  - name: "🧯Fallback"
     type: fallback
     # use:
     #   - DuckDuckGo
@@ -232,13 +279,31 @@ proxy-groups:
     interval: 300
 
   # 代理节点选择
-  - name: "PROXY"
+  - name: "🌑Proxy"
     type: select
     proxies:
-      - Fallback
+      - 🧯Fallback
       - CN1
       - CN2
       - CN3
+      - 🦆DuckDuckGo # 嵌套使用订阅节点策略组
+
+  # 白名单模式 PROXY, 黑名单模式 DIRECT, 不知道别动
+  - name: "🧭Final"
+    type: select
+    proxies:
+      - 🌑Proxy
+      - DIRECT
+
+  # 中国流媒体服务
+  - name: "🎞StreamingCN"
+    type: select
+    proxies:
+      - 🌑Proxy
+      - 1
+      - 2
+      - 3
+      # - US
 
 rule-providers:
   # name: # Provider 名称
@@ -248,16 +313,38 @@ rule-providers:
   #   url: # 只有当类型为 HTTP 时才可用，您不需要在本地空间中创建新文件。
   #   interval: # 自动更新间隔，仅在类型为 HTTP 时可用
 
-  StreamingCN:
+
+  Advertising:
+    type: http
+    behavior: classical
+    path: ./RuleSet/Guard/Advertising.yaml
+    url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Advertising.yaml
+    interval: 86400
+
+  Privacy:
+    type: http
+    behavior: classical
+    path: ./RuleSet/Guard/Privacy.yaml
+    url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Privacy.yaml
+    interval: 86400
+
+    StreamingCN:
     type: http
     behavior: classical
     path: ./RuleSet/StreamingMedia/StreamingCN.yaml
     url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/StreamingMedia/StreamingCN.yaml
     interval: 86400
 
+# 规则
 rules:
+  # Global Area Network
 
-  - RULE-SET,StreamingCN,PROXY
+  # (Guard)
+  - RULE-SET,Advertising,🛡Guard
+  - RULE-SET,Privacy,🛡Guard
+
+  # (StreamingCN)
+  - RULE-SET,StreamingCN,🌑Proxy
 
   # Local Area Network
   - IP-CIDR,192.168.0.0/16,DIRECT
@@ -268,6 +355,6 @@ rules:
   - IP-CIDR,224.0.0.0/4,DIRECT
 
   # GeoIP China
-  - GEOIP,CN,PROXY
+  - GEOIP,CN,🌑Proxy
 
-  - MATCH,DIRECT
+  - MATCH,🧭Final

--- a/Clash/Outbound.yaml
+++ b/Clash/Outbound.yaml
@@ -271,10 +271,11 @@ proxy-groups:
   # 但如果订阅节点很多选起来就很麻烦，不如先嵌套一个策略组进行手动或自动的选择。
 
   # 手动选择订阅节点
-  - name: "DuckDuckGo"
+  - name: "🦆DuckDuckGo"
     type: select # 亦可使用 fallback 或 load-balance
     use: # 注意此处是「use」
       - DuckDuckGoList # 这是上面「proxy-providers」的名称
+      - DuckDuckGoUS # 这是上面「proxy-providers」的名称
 
   # - name: "US"
   #   type: select # 亦可使用 fallback 或 load-balance
@@ -282,8 +283,12 @@ proxy-groups:
   #     - DuckDuckGoUS # 这是上面「proxy-providers」的名称
 
   # Fallback 比较实用的策略组类型，用于测试服务器节点的可用性，当第一个节点不可用时切换到第二个，以此类推。
-  - name: "Fallback"
+  # Fallback
+  - name: "🧯Fallback"
     type: fallback
+    # use:
+    #   - DuckDuckGoList
+    #   - DuckDuckGoUS
     proxies:
       - 1
       - 2
@@ -292,27 +297,27 @@ proxy-groups:
     interval: 300
 
   # 代理节点选择
-  - name: "PROXY"
+  - name: "🌑Proxy"
     type: select
     proxies:
-      - Fallback
+      - 🧯Fallback
       - 1
       - 2
       - 3
-      - DuckDuckGo # 嵌套使用订阅节点策略组
+      - 🦆DuckDuckGo # 嵌套使用订阅节点策略组
 
   # 白名单模式 PROXY, 黑名单模式 DIRECT, 不知道别动
-  - name: "MATCH"
+  - name: "🧭Final"
     type: select
     proxies:
-      - PROXY
+      - 🌑Proxy
       - DIRECT
 
   # 国际流媒体服务
-  - name: "Streaming"
+  - name: "🎞Streaming"
     type: select
     proxies:
-      - PROXY
+      - 🌑Proxy
       - 1
       - 2
       - 3
@@ -320,7 +325,7 @@ proxy-groups:
 
   # 中国流媒体服务（面向海外版本）
   # 用于观看部分国内流媒体面向港澳台的地区的限定内容，此处应放港澳台节点，如果没有此需求可删除此处策略组及相关规则
-  - name: "StreamingSE"
+  - name: "🎞StreamingSE"
     type: select
     proxies:
       - DIRECT
@@ -341,6 +346,27 @@ rule-providers:
     behavior: classical
     path: ./RuleSet/Unbreak.yaml
     url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Unbreak.yaml
+    interval: 86400
+
+  Advertising:
+    type: http
+    behavior: classical
+    path: ./RuleSet/Guard/Advertising.yaml
+    url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Advertising.yaml
+    interval: 86400
+
+  Privacy:
+    type: http
+    behavior: classical
+    path: ./RuleSet/Guard/Privacy.yaml
+    url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Privacy.yaml
+    interval: 86400
+
+  Hijacking:
+    type: http
+    behavior: classical
+    path: ./RuleSet/Guard/Hijacking.yaml
+    url: https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/RuleSet/Guard/Hijacking.yaml
     interval: 86400
 
   Streaming:
@@ -385,14 +411,19 @@ rules:
 
   # Global Area Network
 
+  # (Guard)
+  - RULE-SET,Advertising,🛡Guard
+  - RULE-SET,Privacy,🛡Guard
+  - RULE-SET,Hijacking,🛡Guard
+ 
   # (Streaming Media)
-  - RULE-SET,Streaming,Streaming
+  - RULE-SET,Streaming,🎞Streaming
 
   # (StreamingSE)
-  - RULE-SET,StreamingSE,StreamingSE
+  - RULE-SET,StreamingSE,🎞StreamingSE
 
   # (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
-  - RULE-SET,Global,PROXY
+  - RULE-SET,Global,🌑Proxy
 
   # China Area Network
   - RULE-SET,China,DIRECT
@@ -414,4 +445,4 @@ rules:
   # GeoIP China
   - GEOIP,CN,DIRECT
 
-  - MATCH,MATCH
+  - MATCH,🧭Final

--- a/DivineEngine_Profiles.ini
+++ b/DivineEngine_Profiles.ini
@@ -1,0 +1,54 @@
+[custom]
+;This is an example external configuration file
+;All possible customization settings are shown below
+
+;Options for custom groups
+;设置分组标志位
+
+; 节点选项
+;🌑Proxy = select,🧯Fallback,🕹AutoTest
+custom_proxy_group=🌑Proxy`select`[]🧯Fallback`[]🕹AutoTest`.*
+
+; 国际流媒体服务
+;🎞Streaming = select,🌑Proxy,🕹AutoTest,🦆DuckDuckGo
+custom_proxy_group=🎞Streaming`select`🕹AutoTest`(NF|nf|nfo|Netflix|netflix|网飞|奈菲|NFLX|nflx|BBC|bbc|han4|流媒体|Media|media|视频|FOX|Dinsey|HBO|Hulu)
+
+; 中国流媒体服务（面向海外版本）
+;🎞StreamingSE = select,🌐Direct,🇭🇰Sandbox
+custom_proxy_group=🎞StreamingSE`select`[]DIRECT`(中|CN|cn|港|HK|hk|台|TW|tw|澳门|MO|新加坡|SG|sg|bili|爱奇艺|iQiyi|iqiyi|巴哈|动画疯|芒果|WeTV|腾讯)
+
+; 游戏模式（⚠️所用节点需开启 UDP 转发支持）
+{% if exists("request.game") and bool(request.game) %}
+custom_proxy_group=🎮Game`select`[]DIRECT`(游戏|遊戲|Game|UDP)
+{% endif %}
+
+; 防御
+;🛡Guard = select,⛔️Reject,🌐Direct
+custom_proxy_group=🛡Guard`select`[]REJECT`[]🧭Final
+
+; 可用性自动测试
+;🧯Fallback = fallback,🇺🇸LosSantos,🇨🇳TheHub,url = http://www.gstatic.com/generate_204
+custom_proxy_group=🧯Fallback`fallback`.*`http://www.gstatic.com/generate_204`300,,50
+
+; 延迟自动测试
+;🕹AutoTest = url-test,🦆DuckDuckGo,🇺🇸LosSantos,🇭🇰Sandbox,url = http://www.gstatic.com/generate_204
+custom_proxy_group=🕹AutoTest`url-test`.*`http://www.gstatic.com/generate_204`300,,50
+
+; 白名单模式 PROXY，黑名单模式 DIRECT
+;🧭Final = select,🌑Proxy,🌐Direct
+custom_proxy_group=🧭Final`select`[]🌑Proxy`[]DIRECT
+;设置分组标志位
+
+;Options for custom rulesets
+;设置规则标志位
+enable_rule_generator=false
+overwrite_original_rules=false
+{% if exists("request.game") and bool(request.game) %}
+ruleset=🎮Game,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Extra/Game/Game.list
+{% endif %}
+;设置规则标志位
+
+;Options for custom base configuration file
+surge_rule_base=https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Outbound.conf
+clash_rule_base=https://raw.githubusercontent.com/DivineEngine/Profiles/master/Clash/Outbound.yaml
+quanx_rule_base=https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Outbound.conf

--- a/Quantumult/Inbound.conf
+++ b/Quantumult/Inbound.conf
@@ -12,19 +12,22 @@
 resource_parser_url=https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/resource-parser.js
 
 ;geo_location_checker=http://www.example.com/json/, https://www.example.com/script.js
+;geo_location_checker=http://ip-api.com/json/?lang=zh-CN, https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/IP_API.js
 
 # Quantumult 使用 HEAD 方法将 HTTP 请求发送到服务器检查 url 来测试代理的状态，结果应该是两个延迟，第一个是 TCP 与代理服务器的握手，第二个是 Quantumult 成功地从服务器检查 url 接收 HTTP 响应的总时间。闪电图标表示 TCP Fast Open 成功。如果 [server_local] 或 [server_remote] 中的服务器有自己的 server_check_url，则会用自己的 server_check_url 代替 [general] 中的 server_check_url。
 # Quantumult 使用 HTTP HEAD 方法对测试网址 server_check_url 进行网页响应性测试（测试结果为通过该节点访问此网页获得 HTTP 响应所需要的时间），来确认节点的可用性。
 # Quantumult 界面中的延迟测试方式均为网页响应性测试，显示的最终延迟均为通过对应节点访问测试网页获得 HTTP 响应所需要时间。
 # 由于 Trojan 协议为无响应校验协议，使得 HTTP 检测方式即使获得了 HTTP 响应，也不代表节点一定可用。
 ;server_check_url=http://cp.cloudflare.com/generate_204
+;server_check_url=http://www.gstatic.com/generate_204
+;network_check_url=http://bing.com/
 
 # DNS 排除列表
 # dns_exclusion_list 包含了禁用占位符 IP (240.*) 的域，不在 dns_exclusion_list 中的域都启用了占位符 IP，并打开了 resolve-on-remote 设置。
-;dns_exclusion_list = *.cmpassport.com, *.jegotrip.com.cn, *.icitymobile.mobi, *.pingan.com.cn, *.cmbchina.com, *.localnetwork.uop
+;dns_exclusion_list=*.cmpassport.com, *.jegotrip.com.cn, *.icitymobile.mobi, *.pingan.com.cn, *.cmbchina.com, *.localnetwork.uop
 
 # Quantumult 将不会处理到 excluded_routes 的流量。修改后最好重新启动您的设备。
-;excluded_routes= 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8
+;excluded_routes=192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8
 
 # 在网络环境切换时出发运行模式变更
 # filter - 规则分流，all_proxy - 全部代理，all_direct - 全部直连
@@ -50,9 +53,11 @@ resource_parser_url=https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/maste
 # 禁用系统 DNS
 ;no-system
 
-# 第三方 DNS
+# 自定义 DNS
 server=1.0.0.1
 server=8.8.4.4
+# 本地 DNS 映射
+;server=/*testflight.apple.com/23.76.66.98
 ;server=8.8.4.4:53
 ;server=/example0.com/system
 ;server=/example1.com/8.8.4.4
@@ -68,17 +73,36 @@ server=8.8.4.4
 #
 
 # 静态策略（static）指向您手动选择的候选服务器。
+# 指向您手动选择的候选服务器。
 ;static=policy-name-1, Sample-A, Sample-B, Sample-C, img-url=http://example.com/icon.png
 
-# 健康策略（available）指向候选服务器的第一个可用服务器(当策略被触发且策略结果不可用时，将立即启动并发 url 延迟测试。如果当时没有网络请求接受策略，这意味着策略处于空闲状态，即使服务器关闭，测试也不会启动。那时，您可以通过手动启动测试来更新服务器状态，但是这没有任何意义)。
+# 类型：可用(available)
+# 指向候选服务器的第一个可用服务器(当策略被触发且策略结果不可用时，将立即启动并发 url 延迟测试。
+# 如果当时没有网络请求接受策略，这意味着策略处于空闲状态，即使服务器关闭，测试也不会启动。那时，您可以通过手动启动测试来更新服务器状态，但是这没有任何意义)。
 ;available=policy-name-2, Sample-A, Sample-B, Sample-C
 
-# 负载均衡（round-robin）指向在候选服务器中指向下一个服务器以进行下一次连接。
+# 类型：负载均衡(round-robin)
+# 指向在候选服务器中指向下一个服务器以进行下一次连接。
 ;round-robin=policy-name-3, Sample-A, Sample-B, Sample-C
 
-# SSID 策略根据网络环境的不同指向服务器。
+# 类型：延迟测试(url-latency-benchmark)
+# 策略指向具有最佳 URL 延迟(公差，单位毫秒)结果的服务器。
+# 当用户在 Quantumult X 中手动启动 URL 测试时，策略结果也会被更新。
+# 该类型的策略有一个名为 check-interval(秒) 的参数，如果此策略已经被任何请求激活，则将考虑该间隔。
+;url-latency-benchmark=policy-name-8, resource-tag-regex=^sample, server-tag-regex=^example, check-interval=600, tolerance=0
+
+# SSID
+# 策略根据网络环境的不同指向服务器。
 ;ssid=policy-name-4, Sample-A, Sample-B, LINK_22E171:Sample-B, LINK_22E172:Sample-C
 
+# resource-tag-regex 及 server-tag-regex 仅适用于 static、available 和 round-robin 类型的策略。
+;static=policy-name-5, resource-tag-regex=^sample, server-tag-regex=^example, img-url=http://example.com/icon.png
+;available=policy-name-6, resource-tag-regex=^sample, server-tag-regex=^example
+;round-robin=policy-name-7, resource-tag-regex=^sample, server-tag-regex=^example
+
+static=🧭Final, proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Final.png
+static=🎞StreamingCN, direct, proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/StreamingCN.png
+static=🛡Guard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Hijacking.png
 [server_remote]
 #
 # 参数「tag」和「enabled」是可选的。
@@ -93,17 +117,17 @@ server=8.8.4.4
 #
 
 # Unbreak 后续规则修正
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Unbreak.list, tag=🔂Unbreak, enabled=false
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Unbreak.list, tag=🔂Unbreak, update-interval=86400, enabled=false
 
 # Advertising 广告
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Advertising.list, tag=🛡Advertising, force-policy=Guard, enabled=false
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Advertising.list, tag=🛡Advertising, force-policy=🛡Guard, update-interval=86400, opt-parser=false, enabled=false
 
 # Privacy 隐私
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Privacy.list, tag=🛡️Privacy, force-policy=Guard, enabled=false
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Privacy.list, tag=🛡️Privacy, force-policy=🛡Guard, update-interval=86400, opt-parser=false, enabled=false
 
 
 # StreamingCN 中国流媒体服务
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/StreamingCN.list, tag=🎞StreamingCN, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/StreamingCN.list, tag=🎞StreamingCN,  update-interval=86400, force-policy=🎞StreamingCN, enabled=true
 
 
 [rewrite_remote]
@@ -111,7 +135,7 @@ https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter
 # 参数「tag」和「enabled」是可选的。
 #
 
-# 通用
+# General 通用
 https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Rewrite/General.conf, tag=🔀General, enabled=true
 
 # Advertising 广告
@@ -127,7 +151,8 @@ https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Rewrit
 # obfs plugin tls1.2 ticket auth 比 tls1.2 ticket fastauth 和 obfs tls 多一个 RTT，你最好使用 tls1.2 ticket fastauth。
 # chacha20-ietf-poly1305 和 chacha20-poly1305 在 VMess 配置中具有相同的效果。
 #
-# 可选字段 tls13仅用于：shadowsocks obfs=wss / vmess obfs=over-tls and obfs=wss / http over-tls=true / trojan over-tls=true
+# 可选字段 tls13 仅用于：shadowsocks obfs=wss / vmess obfs=over-tls and obfs=wss / http over-tls=true / trojan over-tls=true
+# [server_local] 完整示例请查看「示例」
 
 [filter_local]
 # Local Area Network 局域网
@@ -141,20 +166,47 @@ ip-cidr, 224.0.0.0/24, direct
 # GeoIP China
 geoip, cn, proxy
 
-final, direct
+final, 🧭Final
 
 [rewrite_local]
+# [rewrite_local] 完整示例请查看「示例」
 
 [task_local]
+#
+# $task.fetch() 组成一个 HTTP 请求并处理响应，只支持 text body。如果您想要 serial requests 而不是 current requests，可以将 $task.fetch() 嵌入到另一个 $task.fetch() 的完成处理程序中。
+#
+# 脚本应保存在本地「我的 iPhone - Quantumult X - Scripts」或「iCloud Drive - Quantumult X - Scripts」中。示例：https://github.com/crossutility/Quantumult-X/blob/master/sample-task.js
+#
+# 默认的 HTTP 请求超时是 10 秒。
+#
+# 支持 5 或 6 个 cron 字段，不包括命令字段。
+#
+
+# [task_local] 完整示例请查看「示例」
+
+[http_backend]
+#
+# 部署一个本地 HTTP 服务器，并使用 JavaScript 进行数据处理。
+# 输入变量为：$reqeust.url、$reqeust.path、$reqeust.headers、$reqeust.body。
+# 使用 $done 输出像 $done({status:"HTTP/1.1 200 OK"}, headers:{}, body:"here is a string") 这样的返回响应。
+# 此外，您还可以使用签名或任何其他验证方法来验证请求是否合法。
+# 部署后您应该通过 http://127.0.0.1:9999/your-path/your-api/. 进行访问。服务器默认监听端口为 9999，您可以在UI中进行更改。
+#
+# [http_backend] 完整示例请查看「示例」
 
 [mitm]
 #
 # 只有「hostname」中的 TLS SNI 或目标地址将被 MitM 处理。
 #
-# 您应该始终保护您的 CA 密码和p 12 的私密性。
+# 默认情况下，当为 HTTPS 请求启用 MitM 时，Quantumult X 会从原站点获取证书（证书会被缓存），保留大部分需要的原始证书信息，并使用 MitM 的 root CA 重新签名，这是推荐的（也是比较兼容的）MitM 证书创建方式。
+#
+# 偶尔有些用户喜欢调试 HTTPS 请求，其域名不存在，所以原证书根本不存在。当参数 simple_cert_hostname 出现的时候。其 TLS SNI 名称在 simple_cert_hostname(及 hostname) 中的 HTTPS 请求将使用纯本地生成的 MitM 证书。
+#
+# 注意！！！您应该始终保护您的 CA 密码和 p12 的私密性。
 #
 ;passphrase =
 ;p12 =
 skip_validating_cert = true
 ;force_sni_domain_name = false
+;simple_cert_hostname = non-existed-domain.com, *.non-connected-domain.com
 ;hostname = *.googlevideo.com

--- a/Quantumult/Outbound.conf
+++ b/Quantumult/Outbound.conf
@@ -12,12 +12,14 @@
 resource_parser_url=https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/resource-parser.js
 
 ;geo_location_checker=http://www.example.com/json/, https://www.example.com/script.js
+geo_location_checker=http://ip-api.com/json/?lang=zh-CN, https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/IP_API.js
 
 # Quantumult 使用 HEAD 方法将 HTTP 请求发送到服务器检查 url 来测试代理的状态，结果应该是两个延迟，第一个是 TCP 与代理服务器的握手，第二个是 Quantumult 成功地从服务器检查 url 接收 HTTP 响应的总时间。闪电图标表示 TCP Fast Open 成功。如果 [server_local] 或 [server_remote] 中的服务器有自己的 server_check_url，则会用自己的 server_check_url 代替 [general] 中的 server_check_url。
-# Quantumult 使用 HTTP HEAD 方法对测试网址 server_check_url 进行网页响应性测试(测试结果为通过该节点访问此网页获得 HTTP 响应所需要的时间)，来确认节点的可用性。
+# Quantumult 使用 HTTP HEAD 方法对测试网址 server_check_url 进行网页响应性测试（测试结果为通过该节点访问此网页获得 HTTP 响应所需要的时间），来确认节点的可用性。
 # Quantumult 界面中的延迟测试方式均为网页响应性测试，显示的最终延迟均为通过对应节点访问测试网页获得 HTTP 响应所需要时间。
 # 由于 Trojan 协议为无响应校验协议，使得 HTTP 检测方式即使获得了 HTTP 响应，也不代表节点一定可用。
 server_check_url=http://www.gstatic.com/generate_204
+network_check_url=http://bing.com/
 
 # DNS 排除列表
 # dns_exclusion_list 包含了禁用占位符 IP (240.*) 的域，不在 dns_exclusion_list 中的域都启用了占位符 IP，并打开了 resolve-on-remote 设置。
@@ -30,25 +32,25 @@ excluded_routes=239.255.255.250/32
 # 在网络环境切换时出发运行模式变更
 # filter - 规则分流，all_proxy - 全部代理，all_direct - 全部直连
 # 示例意思：[蜂窝数据],[Wi-Fi],[SSID]
-# 下列示例的意思为：在蜂窝数据使用规则分流(第一个 filter)，在 Wi-Fi 使用规则分流(第二个 filter)，在 SSID 为 LINK_22E171 的 Wi-Fi 使用全部代理，，在 SSID 为 LINK_22E172 的 Wi-Fi 使用全部直连
+# 下列示例的意思为：在蜂窝数据使用规则分流（第一个 filter），在 Wi-Fi 使用规则分流（第二个 filter），在 SSID 为 LINK_22E171 的 Wi-Fi 使用全部代理，，在 SSID 为 LINK_22E172 的 Wi-Fi 使用全部直连
 # Rewrite 及 Task 模块始终生效
 ;running_mode_trigger=filter, filter, LINK_22E171:all_proxy, LINK_22E172:all_direct
 
-# 在特定 SSID 网络时(除了 Task 模块)暂停 Quantumult X
+# 在特定 SSID 网络时（除了 Task 模块）暂停 Quantumult X
 ;ssid_suspended_list=LINK_22E174, LINK_22E175
 
-# udp_whitelist 包含目标 UDP 端口，空表示所有的端口都在 udp_whitelist 中。通过Quantumult 隧道接口发送的 UDP 数据包(通过 Quantumult 隧道接口)，目标端口不在 udp_whitelist 中的 UDP 包将被丢弃。这个设置与策略无关，也与代理(服务器)端口无关。
+# udp_whitelist 包含目标 UDP 端口，空表示所有的端口都在 udp_whitelist 中。通过Quantumult 隧道接口发送的 UDP 数据包（通过 Quantumult 隧道接口），目标端口不在 udp_whitelist 中的 UDP 包将被丢弃。这个设置与策略无关，也与代理（服务器）端口无关。
 ;udp_whitelist=53, 123, 1900, 80-443
 
 ;icmp_auto_reply=true
 
 
 [dns]
+# 为了提高性能，会使用从当前网络（系统）中获取的DNS服务器（您可以使用「no-system」禁用此功能，但至少要增加一个自定义的DNS服务器，如「server=223.5.5.5.5」）。
 # 查询结果只用于评估过滤器或通过直接策略连接，当通过服务器连接时，查询结果不会被使用，Quantumult 永远不会知道相关域名的目标 IP。
-# 如果您想让某个域名(例如：example.com)为 127.0.0.0.1，只需在「filter_local」部分添加「host, example.com, reject」即可。拒绝操作将返回 127.0.0.0.1 的 DNS 响应。
+# 如果您想让某个域名（例如：example.com）为 127.0.0.0.1，只需在「filter_local」部分添加「host, example.com, reject」即可。拒绝操作将返回 127.0.0.0.1 的 DNS 响应。
 
 # 禁用系统 DNS
-# 为了提高性能，会使用从当前网络(系统)中获取的 DNS 服务器(您可以使用「no-system」禁用此功能，但至少要增加一个自定义的DNS服务器，如「server=223.5.5.5.5」)。
 ;no-system
 
 # 禁用 IPv6
@@ -58,8 +60,10 @@ no-ipv6
 # 自定义 DNS
 # > DNSPod Public DNS
 server=119.29.29.29
+server=119.28.28.28
 # > Alibaba Public DNS
-# server=223.5.5.5
+server=223.5.5.5
+server=223.6.6.6
 
 # 本地 DNS 映射
 # Firebase Cloud Messaging
@@ -67,7 +71,26 @@ address=/mtalk.google.com/108.177.125.188
 # Google Dl
 server=/dl.google.com/119.29.29.29
 server=/dl.l.google.com/119.29.29.29
-
+;指定域名解析dns
+server=/*.taobao.com/223.5.5.5
+server=/*.tmall.com/223.5.5.5
+server=/*.alipay.com/223.5.5.5
+server=/*.alicdn.com/223.5.5.5
+server=/*.aliyun.com/223.5.5.5
+server=/*.jd.com/119.28.28.28
+server=/*.qq.com/119.28.28.28
+server=/*.tencent.com/119.28.28.28
+server=/*.weixin.com/119.28.28.28
+server=/*.bilibili.com/119.29.29.29
+server=/hdslb.com/119.29.29.29
+server=/*.163.com/119.29.29.29
+server=/*.126.com/119.29.29.29
+server=/*.126.net/119.29.29.29
+server=/*.127.net/119.29.29.29
+server=/*.netease.com/119.29.29.29
+server=/*.mi.com/119.29.29.29
+server=/*.xiaomi.com/119.29.29.29
+;server=/*testflight.apple.com/23.76.66.98
 ;server=8.8.4.4:53
 ;server=/example0.com/system
 ;server=/example1.com/8.8.4.4
@@ -82,7 +105,7 @@ server=/dl.l.google.com/119.29.29.29
 # 需要策略图标的在策略后加上：img-url=http://example.com/icon.png
 #
 
-# 类型：静态(static)
+# 静态策略（static）指向您手动选择的候选服务器。
 # 指向您手动选择的候选服务器。
 ;static=policy-name-1, Sample-A, Sample-B, Sample-C, img-url=http://example.com/icon.png
 
@@ -110,10 +133,10 @@ server=/dl.l.google.com/119.29.29.29
 ;available=policy-name-6, resource-tag-regex=^sample, server-tag-regex=^example
 ;round-robin=policy-name-7, resource-tag-regex=^sample, server-tag-regex=^example
 
-static=Final, proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Final.png
-static=Streaming, proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Streaming.png
-static=StreamingSE, direct, proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/StreamingSE.png
-static=Guard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Hijacking.png
+static=🧭Final, proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Final.png
+static=🎞Streaming, proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Streaming.png
+static=🎞StreamingSE, direct, proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/StreamingSE.png
+static=🛡Guard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Hijacking.png
 
 [server_remote]
 #
@@ -132,22 +155,22 @@ static=Guard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/
 https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Unbreak.list, tag=🔂Unbreak, update-interval=86400, enabled=true
 
 # Advertising 广告
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Advertising.list, tag=🛡Advertising, update-interval=86400, force-policy=Guard, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Advertising.list, tag=🛡Advertising, force-policy=🛡Guard, update-interval=86400, opt-parser=false, enabled=true
 
 # Privacy 隐私
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Privacy.list, tag=🛡️Privacy, update-interval=86400, force-policy=Guard, enabled=false
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Privacy.list, tag=🛡️Privacy, force-policy=🛡Guard, update-interval=86400, opt-parser=false, enabled=false
 
 # Hijacking 运营商劫持或恶意网站
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Hijacking.list, tag=🛡️Hijacking, update-interval=86400, force-policy=Guard, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Guard/Hijacking.list, tag=🛡️Hijacking, force-policy=🛡Guard, update-interval=86400, opt-parser=false, enabled=true
 
 # Streaming 国际流媒体服务
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/Streaming.list, tag=🎞Streaming, update-interval=86400, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/Streaming.list, tag=🎞Streaming, update-interval=86400, force-policy=🎞Streaming, enabled=true
 
 # StreamingSE 中国流媒体服务(面向海外版本)
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/StreamingSE.list, tag=🎞StreamingSE, update-interval=86400, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/StreamingMedia/StreamingSE.list, tag=🎞StreamingSE, update-interval=86400, force-policy=🎞StreamingSE, enabled=true
 
 # Global 全球加速
-https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Global.list, tag=🇺🇳Global, update-interval=86400, enabled=true
+https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/Global.list, tag=🇺🇳Global, update-interval=86400, force-policy=🌑Proxy, enabled=true
 
 # China 中国直连
 https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter/China.list, tag=🇨🇳China, update-interval=86400, enabled=true
@@ -160,7 +183,7 @@ https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Filter
 # 参数「tag」和「enabled」是可选的。
 #
 
-# General
+# General 通用
 https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Rewrite/General.conf, tag=🔀General, update-interval=86400, enabled=true
 
 # Block Advertising
@@ -177,6 +200,7 @@ https://raw.githubusercontent.com/DivineEngine/Profiles/master/Quantumult/Rewrit
 # 只有 obfs=http, obfs=ws, obfs=ws, obfs=wss 可以有可选的「obfs-uri」字段。
 # wss 中的 obfs-host 参数将用于 TLS 握手和 HTTP 头主机字段，如果没有为 wss 设置 obfs-host，则将使用服务器地址。
 # 目前不支持 VMess 和 Trojan 的 UDP relay。
+# When using obfs=ws and obfs=wss the server side can be deployed by v2ray-plugin with mux = 0 or by v2ray-core.
 # 当使用 obfs=ws 和 obfs=wss 时，服务器端可以通过带有 mux=0 的 v2ray-plugin 或 v2ray-core 进行部署。
 # obfs plugin tls1.2 ticket auth 比 tls1.2 ticket fastauth 和 obfs tls 多一个 RTT，你最好使用 tls1.2 ticket fastauth。
 # chacha20-ietf-poly1305 和 chacha20-poly1305 在 VMess 配置中具有相同的效果。
@@ -198,7 +222,7 @@ ip6-cidr, fe80::/10, direct
 # GeoIP China(若启用，则禁用 ChinaIP.list)
 -geoip, cn, direct
 
-final, Final
+final, 🧭Final
 
 [rewrite_local]
 # [rewrite_local] 完整示例请查看「示例」

--- a/Surge/Inbound.conf
+++ b/Surge/Inbound.conf
@@ -28,7 +28,7 @@ keyword-filter=(null)
 
 [Rule]
 # Unbreak 后续规则修正
-RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Unbreak.list,🌐Direct
+RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Unbreak.list,DIRECT
 
 # Advertising 广告
 RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Guard/Advertising.list,🛡Guard
@@ -40,9 +40,9 @@ RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ru
 RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/StreamingMedia/StreamingCN.list,🌑Proxy
 
 # Local Area Network 局域网
-RULE-SET,LAN,🌐Direct
+RULE-SET,LAN,DIRECT
 
 # GeoIP China
 # GEOIP,CN,🌑Proxy
 
-FINAL,🌐Direct
+FINAL,DIRECT

--- a/Surge/Outbound.conf
+++ b/Surge/Outbound.conf
@@ -5,21 +5,34 @@
 # 延迟测试
 # > Internet 测试 URL
 internet-test-url = http://www.aliyun.com
+# server_check_url= http://www.qualcomm.cn/generate_204
 # > 代理测速 URL
 proxy-test-url = http://www.gstatic.com/generate_204
 # > 测试超时（秒）
 # test-timeout = 5
 # TLS 引擎
 tls-provider = openssl
+# tls-provider = network-framework
 # GeoIP 数据库
+# geoip-maxmind-url = https://github.com/soffchen/GeoIP2-CN/raw/release/Country.mmdb
 geoip-maxmind-url = https://raw.githubusercontent.com/JMVoid/ipip2mmdb/release/Country.mmdb
 # IPv6 支持（关闭）
+# 是否启动完整的 IPv6 支持 (默认值: false)
 ipv6 = false
 # ------
 
 # ---(Wi-Fi 访问)---
+# Surge 作为 HTTP/SOCKS5 代理服务器向 Wi-Fi 网络下的其他设备提供服务器
 allow-wifi-access = false
+# Surge Mac 供外网访问的服务端口
+#  HTTP 服务端口 (默认值: 6152)
+# http-listen = 0.0.0.0:7222
+#  SOCKS5 服务端口 (默认值: 6153)
+# socks5-listen = 0.0.0.0:7221
+# Surge iOS 供外网访问的服务端口
+#  HTTP 服务端口 (默认值: 6152)
 wifi-access-http-port = 6152
+#  SOCKS5 服务端口 (默认值: 6153)
 wifi-access-socks5-port = 6153
 # ------
 
@@ -32,7 +45,8 @@ wifi-access-socks5-port = 6153
 # ---(兼容性)---
 # 兼容模式
 # compatibility-mode = 0
-# 跳过代理
+# 跳过某个域名或者 IP 段，这些目标主机将不会由 Surge Proxy 处理。
+# (macOS 版本中，如果启用了 Set as System Proxy, 这些值会被写入到系统网络代理设置.)
 skip-proxy = 127.0.0.1, 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 100.64.0.0/10, localhost, *.local
 # 排除简单主机名
 exclude-simple-hostnames = true
@@ -44,7 +58,9 @@ use-default-policy-if-wifi-not-primary = false
 # ---(DNS 服务器)---
 # 电信 118.118.118.118
 # 联通 116.116.116.116
+# DNS设置或根据自己网络情况进行相应设置
 dns-server = 119.29.29.29,system
+# doh-server = https://223.6.6.6/dns-query
 # ------
 
 # ---(实验性功能)---
@@ -53,7 +69,7 @@ dns-server = 119.29.29.29,system
 # ------
 
 # ---(高级)---
-# 日志级别
+# 日志等级: warning, notify, info, verbose (默认值: notify)
 loglevel = notify
 
 # 当遇到 REJECT 策略时返回错误页
@@ -83,14 +99,19 @@ force-http-engine-hosts = *.ott.cibntv.net,123.59.31.1,119.18.193.135,122.14.246
 # ------
 
 [Replica]
+# [抓取流量] => 过滤器
 # ---(实验性功能)---
 # 0 为关闭，1 为开启
 # > 隐藏 Apple 请求
-hide-apple-request=0
+# 隐藏所有发往 *.Apple.com he *.icloud.com 的请求
+# （该选项只是在抓取结果中隐藏了请求）
+hide-apple-request = 0
+# > 隐藏 Crashlytics 请求
+hide-crashlytics-request = true
 # > 隐藏崩溃追踪器请求
-hide-crash-reporter-request=1
+hide-crash-reporter-request = 1
 # > 隐藏 UDP 会话
-hide-udp=0
+hide-ud = 0
 # > 关键词过滤器
 # none（关闭关键词过滤器） / whitelist（blacklist（仅记录包含关键字的请求）） / blacklist（仅记录不包含关键字的请求） / pattern（匹配通配符的请求）
 # keyword-filter-type = none
@@ -128,22 +149,27 @@ hide-udp=0
 
 # Client
 # > Proxy
-PROCESS-NAME,v2ray,🌐Direct
-PROCESS-NAME,ss-local,🌐Direct
-PROCESS-NAME,UUBooster,🌐Direct
+PROCESS-NAME,v2ray,DIRECT
+PROCESS-NAME,ss-local,DIRECT
+PROCESS-NAME,UUBooster,DIRECT
 # > Download
-PROCESS-NAME,aria2c,🌐Direct
-PROCESS-NAME,fdm,🌐Direct
-PROCESS-NAME,Folx,🌐Direct
-PROCESS-NAME,NetTransport,🌐Direct
-PROCESS-NAME,Thunder,🌐Direct
-PROCESS-NAME,Transmission,🌐Direct
-PROCESS-NAME,uTorrent,🌐Direct
-PROCESS-NAME,WebTorrent,🌐Direct
-PROCESS-NAME,WebTorrent Helper,🌐Direct
+PROCESS-NAME,aria2c,DIRECT
+PROCESS-NAME,fdm,DIRECT
+PROCESS-NAME,Folx,DIRECT
+PROCESS-NAME,NetTransport,DIRECT
+PROCESS-NAME,Thunder,DIRECT
+PROCESS-NAME,Transmission,DIRECT
+PROCESS-NAME,uTorrent,DIRECT
+PROCESS-NAME,WebTorrent,DIRECT
+PROCESS-NAME,WebTorrent Helper,DIRECT
+
+# Rulesets，规则集（每 24 小时后台自动更新）
+# 规则集包含多条子规则，可以是另一个本地 list 文件，或者是一个 URL
+# 内置了两个规则集：SYSTEM 和 LAN
+# 内置规则集的具体内容可在 Surge Mac 设置界面查看
 
 # Unbreak 后续规则修正
-RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Unbreak.list,🌐Direct
+RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Unbreak.list,DIRECT
 
 # Advertising 广告
 RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Guard/Advertising.list,🛡Guard
@@ -167,14 +193,15 @@ RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ru
 RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/Global.list,🌑Proxy
 
 # China 中国直连
-RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/China.list,🌐Direct
+RULE-SET,https://raw.githubusercontent.com/DivineEngine/Profiles/master/Surge/Ruleset/China.list,DIRECT
 
 # Local Area Network 局域网
-RULE-SET,LAN,🌐Direct
+RULE-SET,LAN,DIRECT
 
-# GeoIP China
-GEOIP,CN,🌐Direct
+# GeoIP China，基于 GeoIP 数据库判断域名和 IP 的归属地
+GEOIP,CN,DIRECT
 
+# DNS 查询失败走 Final 规则
 FINAL,🧭Final,dns-failed
 
 [Host]
@@ -184,7 +211,8 @@ mtalk.google.com = 108.177.125.188
 dl.google.com = server:119.29.29.29
 dl.l.google.com = server:119.29.29.29
 
-[Header Rewrite]
+# 该段定义针对 HTTP 请求的 URL 重定向规则
+# 有两种重定向方式: "header" 和 "302"
 
 # 据粗略统计，有大概三分之二的本项目使用者停留在了 Surge 2、3 时期故而保留了 Rewrite 及 MitM，所以如果你解锁了「模块」功能可以使用 sgmodule 后清空 [URL Rewrite] 及 [MITM] 部分，MitM 证书重新生成配置。
 
@@ -264,9 +292,16 @@ dl.l.google.com = server:119.29.29.29
 
 # Block Ads End
 
+[Header Rewrite]
+# 重定向 HTTP 请求或者篡改请求 Header
+# Surge 可以在请求被发往目标服务器之前篡改请求的 Header
+
 [Script]
 
 [SSID Setting]
+# 连接到 Apple Store 的 Wi-Fi网络时 Surge 暂停工作
+# 需要 Web 验证登录的 Wi-Fi 网络以及路由器已经科学上网的 Surge 挂起
+"Apple Store" suspend = true
 
 [MITM]
 skip-server-cert-verify = true


### PR DESCRIPTION
3 in 1 (Surge/Clash/Quantumult X) external configs for subconverter
Replace the %CONFIG% in the subscription link to 'DivineEngine_Profiles.ini' path, then specify the %TARGET% type as u need.
Just a thought it would provide convenience, if you don’t need, just close this Pull request.