### PR TITLE
fix Netflix dualstack.

### DIFF
--- a/Clash/RuleSet/StreamingMedia/Streaming.yaml
+++ b/Clash/RuleSet/StreamingMedia/Streaming.yaml
@@ -208,7 +208,7 @@ payload:
   - DOMAIN-SUFFIX,netflixdnstest7.com
   - DOMAIN-SUFFIX,netflixdnstest8.com
   - DOMAIN-SUFFIX,netflixdnstest9.com
-  - DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-
+  - DOMAIN-KEYWORD,dualstack.apiproxy-
   - DOMAIN-KEYWORD,dualstack.ichnaea-web-
   - IP-CIDR,23.246.0.0/18,no-resolve
   - IP-CIDR,37.77.184.0/21,no-resolve

--- a/Clash/RuleSet/StreamingMedia/Video/Netflix.yaml
+++ b/Clash/RuleSet/StreamingMedia/Video/Netflix.yaml
@@ -18,7 +18,7 @@ payload:
   - DOMAIN-SUFFIX,netflixdnstest7.com
   - DOMAIN-SUFFIX,netflixdnstest8.com
   - DOMAIN-SUFFIX,netflixdnstest9.com
-  - DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-
+  - DOMAIN-KEYWORD,dualstack.apiproxy-
   - DOMAIN-KEYWORD,dualstack.ichnaea-web-
   - IP-CIDR,23.246.0.0/18,no-resolve
   - IP-CIDR,37.77.184.0/21,no-resolve

--- a/Quantumult/Filter/StreamingMedia/Streaming.list
+++ b/Quantumult/Filter/StreamingMedia/Streaming.list
@@ -206,7 +206,7 @@ DOMAIN-SUFFIX,netflixdnstest6.com,Streaming
 DOMAIN-SUFFIX,netflixdnstest7.com,Streaming
 DOMAIN-SUFFIX,netflixdnstest8.com,Streaming
 DOMAIN-SUFFIX,netflixdnstest9.com,Streaming
-DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-,Streaming
+DOMAIN-KEYWORD,dualstack.apiproxy-,Streaming
 DOMAIN-KEYWORD,dualstack.ichnaea-web-,Streaming
 IP-CIDR,23.246.0.0/18,Streaming
 IP-CIDR,37.77.184.0/21,Streaming

--- a/Quantumult/Filter/StreamingMedia/Video/Netflix.list
+++ b/Quantumult/Filter/StreamingMedia/Video/Netflix.list
@@ -17,7 +17,7 @@ DOMAIN-SUFFIX,netflixdnstest6.com,Netflix
 DOMAIN-SUFFIX,netflixdnstest7.com,Netflix
 DOMAIN-SUFFIX,netflixdnstest8.com,Netflix
 DOMAIN-SUFFIX,netflixdnstest9.com,Netflix
-DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-,Netflix
+DOMAIN-KEYWORD,dualstack.apiproxy-,Netflix
 DOMAIN-KEYWORD,dualstack.ichnaea-web-,Netflix
 IP-CIDR,23.246.0.0/18,Netflix
 IP-CIDR,37.77.184.0/21,Netflix

--- a/Surge/Ruleset/StreamingMedia/Streaming.list
+++ b/Surge/Ruleset/StreamingMedia/Streaming.list
@@ -206,7 +206,7 @@ DOMAIN-SUFFIX,netflixdnstest6.com
 DOMAIN-SUFFIX,netflixdnstest7.com
 DOMAIN-SUFFIX,netflixdnstest8.com
 DOMAIN-SUFFIX,netflixdnstest9.com
-DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-
+DOMAIN-KEYWORD,dualstack.apiproxy-
 DOMAIN-KEYWORD,dualstack.ichnaea-web-
 IP-CIDR,23.246.0.0/18,no-resolve
 IP-CIDR,37.77.184.0/21,no-resolve

--- a/Surge/Ruleset/StreamingMedia/Video/Netflix.list
+++ b/Surge/Ruleset/StreamingMedia/Video/Netflix.list
@@ -17,7 +17,7 @@ DOMAIN-SUFFIX,netflixdnstest6.com
 DOMAIN-SUFFIX,netflixdnstest7.com
 DOMAIN-SUFFIX,netflixdnstest8.com
 DOMAIN-SUFFIX,netflixdnstest9.com
-DOMAIN-KEYWORD,dualstack.apiproxy-device-prod-nlb-
+DOMAIN-KEYWORD,dualstack.apiproxy-
 DOMAIN-KEYWORD,dualstack.ichnaea-web-
 IP-CIDR,23.246.0.0/18,no-resolve
 IP-CIDR,37.77.184.0/21,no-resolve


### PR DESCRIPTION
最近看Netflix的时候出现了对`dualstack.apiproxy-http1-XXXXXXXXX.us-west-2.elb.amazonaws.com`发起的请求，故修改之前针对`dualstack.apiproxy-device-prod-nlb-XXXXXXXXXXX.elb.us-west-2.amazonaws.com`的`DOMAIN-KEYWORD`条目以扩大匹配范围