### PR TITLE
Add Seafile English manual site

### DIFF
--- a/Clash/RuleSet/Global.yaml
+++ b/Clash/RuleSet/Global.yaml
@@ -466,6 +466,7 @@ payload:
   - DOMAIN,cc.tvbs.com.tw
   - DOMAIN,ocsp.int-x3.letsencrypt.org
   - DOMAIN,us.weibo.com
+  - DOMAIN,manual.seafile.com
 
   - DOMAIN-SUFFIX,edu
   - DOMAIN-SUFFIX,gov


### PR DESCRIPTION
https://manual.seafile.com/ is hosted on Github and cannot be accessed in some areas of mainland China.