### PR TITLE
Add four domains related to iOS software updating

### DIFF
--- a/Clash/RuleSet/Extra/Apple/SoftwareUpdate.yaml
+++ b/Clash/RuleSet/Extra/Apple/SoftwareUpdate.yaml
@@ -18,6 +18,10 @@ payload:
   # > iOS updates
   - DOMAIN,appldnld.apple.com
   - DOMAIN,ns.itunes.apple.com
+  - DOMAIN,ocsp.int-x3.letsencrypt.org
+  - DOMAIN,ocsp.apple.com
+  - DOMAIN,world-gen.g.aaplimg.com
+  - DOMAIN,gdmf.apple.com
   # > iOS, tvOS, and macOS
   - DOMAIN,mesu.apple.com
   - DOMAIN,updates.cdn-apple.com


### PR DESCRIPTION
Add four domains related to iOS software updating:
ocsp.int-x3.letsencrypt.org
ocsp.apple.com
world-gen.g.aaplimg.com
gdmf.apple.com