### PR TITLE
 Remove VIF Excluded Routes

### DIFF
--- a/Surge/Module/General.sgmodule
+++ b/Surge/Module/General.sgmodule
@@ -8,9 +8,6 @@ skip-proxy = %APPEND% passenger.t3go.cn
 # > Always Real IP Hosts
 always-real-ip = %APPEND% *.msftconnecttest.com, *.msftncsi.com, *.srv.nintendo.net, *.stun.playstation.net, xbox.*.microsoft.com, *.xboxlive.com, *.logon.battlenet.com.cn, *.logon.battle.net, stun.l.google.com
 
-# > VIF Excluded Routes
-tun-excluded-routes = %APPEND% 239.255.255.250/32
-
 [Host]
 
 [URL Rewrite]


### PR DESCRIPTION
当 hide-vpn-icon/include-all-networks/include-local-networks/tun-excluded-routes/tun-included-routes 等高级选项开启时，将使用旧版的网络切换逻辑，以避免产生问题。（如无特殊用途以上参数均不建议设置任何内容）