### PR TITLE
Add new domain name for Science Magazine

### DIFF
--- a/Clash/RuleSet/Extra/Scholar.yaml
+++ b/Clash/RuleSet/Extra/Scholar.yaml
@@ -48,6 +48,7 @@ payload:
   - DOMAIN-SUFFIX,proquest.com
   - DOMAIN-SUFFIX,rsc.org
   - DOMAIN-SUFFIX,sagepub.com
+  - DOMAIN-SUFFIX,science.org
   - DOMAIN-SUFFIX,sciencedirect.com
   - DOMAIN-SUFFIX,sciencemag.org
   - DOMAIN-SUFFIX,scitation.org


### PR DESCRIPTION
Science Magazine is using the new domain name "science.org" now.