### PR TITLE
Update China.list: Remove GeoIP Filter

### DIFF
--- a/Surge/Ruleset/China.list
+++ b/Surge/Ruleset/China.list
@@ -69,6 +69,3 @@ DOMAIN-SUFFIX,redacted.ch
 DOMAIN-SUFFIX,springsunday.net
 DOMAIN-SUFFIX,tjupt.org
 DOMAIN-SUFFIX,totheglory.im
-
-# Just for Quantumult X, move GEOIP,CN to the bottom (local filter at the top by default)
-GEOIP,CN,no-resolve


### PR DESCRIPTION
Some users now need to use ASN rules, but when using the file with GeoIP rules at the end, the ASN rules will not work fully.
This rule is added for Quantumult X, but when Quantumult X works, it ignores the no-resolve parameter, causing subsequent ASN rules to completely fail! There is a better solution now, so please remove it.